### PR TITLE
Fixes #2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ An unofficial client for *reading* data from Google Sheets, since [googleapis do
 
     ```javascript
     var fs = require('fs');
-    var Promise = require('bluebird');
     var Sheets = require('google-sheets-api').Sheets;
 
     // TODO: Replace these values with yours
@@ -75,10 +74,10 @@ An unofficial client for *reading* data from Google Sheets, since [googleapis do
         sheets.getRange(documentId, sheetInfo.id, 'A1:C3')
       ]);
     })
-    .spread(function(sheet, rows) {
-      // TODO: Do something with cell within range
-      console.log('Sheets contents:', sheet, rows);
-    })
+	.then(function(sheets) {
+		console.log('Sheets metadata:', sheets[0]);
+		console.log('Sheets contents:', sheets[1]);
+	})
     .catch(function(err){
       console.error(err, 'Failed to read Sheets document');
     });

--- a/lib/sheets.js
+++ b/lib/sheets.js
@@ -1,7 +1,7 @@
 "use strict";
 var _ = require('lodash');
 var google = require('googleapis');
-var Promise = require('bluebird');
+var Promise = require('polyfill-promise');
 var request = require('request');
 
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/SC5/google-sheets-api/issues"
   },
   "dependencies": {
-    "bluebird": "^2.9.14",
+    "polyfill-promise": "^4.0.0",
     "request": "^2.54.0",
     "googleapis": "^2.0.2",
     "lodash": "^3.6.0"

--- a/spec/sheets.spec.js
+++ b/spec/sheets.spec.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var Promise = require('bluebird');
+var Promise = require('polyfill-promise');
 var proxyquire = require('proxyquire');
 
 


### PR DESCRIPTION
Replaced bluebird with node-polyfill-promise.
Updated the example to not use a Bluebird specific method.
Tests are passing in node v0.10.38 and iojs v2.2.1
