### PR TITLE
Parameterize auth scope

### DIFF
--- a/lib/sheets.js
+++ b/lib/sheets.js
@@ -10,7 +10,7 @@ function authorize(options) {
     options.email,
     null,
     options.key,
-    ['https://spreadsheets.google.com/feeds/']
+    [options.baseUrl]
   );
 
   return new Promise(function(resolve, reject) {
@@ -46,7 +46,8 @@ Sheets.prototype.authorize = function() {
   if (!this.authorization || (this.authorization_expiry < new Date())) {
     this.authorization = authorize({
       email: this.email,
-      key: this.key
+      key: this.key,
+      baseUrl: this.baseUrl
     });
 
     this.authorization.then(function(authClient) {


### PR DESCRIPTION
This allows the auth mechanics provided by the lib to be used against other Google APIs.
